### PR TITLE
Fix leadership image sizing

### DIFF
--- a/about.html
+++ b/about.html
@@ -123,8 +123,12 @@
     }
     
     .team-member-image {
-      height: 300px;
+      width: 100%;
+      aspect-ratio: 1 / 1;
       background-color: var(--light-yellow);
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: cover;
     }
     
     .team-member-content {
@@ -295,7 +299,7 @@
       <h2 class="section-title">Our Leadership Team</h2>
       <div class="team-grid">
         <div class="team-member">
-          <div class="team-member-image"      style="background: url('RhiannaHeadshot.jpg') center/cover no-repeat;"></div>
+          <div class="team-member-image" style="background-image: url('RhiannaHeadshot.jpg');"></div>
           <div class="team-member-content">
             <h3 class="team-member-name">Rhianna Scyster</h3>
             <p class="team-member-title">Founder and Director of Strategy</p>
@@ -305,7 +309,7 @@
         </div>
 
         <div class="team-member">
-          <div class="team-member-image"      style="background: url('RenaldoHorn.jpg') center/cover no-repeat;"></div>
+          <div class="team-member-image" style="background-image: url('RenaldoHorn.jpg');"></div>
           <div class="team-member-content">
             <h3 class="team-member-name">Ronaldo Horn</h3>
             <p class="team-member-title">Director of Data and Communications</p>
@@ -314,7 +318,7 @@
         </div>
 
         <div class="team-member">
-          <div class="team-member-image"      style="background: url('TLatriceCarmichael.jpg') center/cover no-repeat;"></div>
+          <div class="team-member-image" style="background-image: url('TLatriceCarmichael.jpg');"></div>
           <div class="team-member-content">
             <h3 class="team-member-name">T. Latrice Carmichael</h3>
             <p class="team-member-title">Director of Community Engagement</p>
@@ -323,7 +327,7 @@
         </div>
 
         <div class="team-member">
-          <div class="team-member-image"      style="background: url('MoniqueStewart.jpg') center/cover no-repeat;"></div>
+          <div class="team-member-image" style="background-image: url('MoniqueStewart.jpg');"></div>
           <div class="team-member-content">
             <h3 class="team-member-name">Monique Stewart</h3>
             <p class="team-member-title">Director of Development</p>

--- a/index.html
+++ b/index.html
@@ -155,8 +155,12 @@
     }
     
     .card-image {
-      height: 200px;
+      width: 100%;
+      aspect-ratio: 1 / 1;
       background-color: var(--light-yellow);
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: cover;
     }
     
     .card-content {
@@ -360,28 +364,28 @@
       <h2 class="section-title">Our Leadership</h2>
       <div class="featured-content">
         <div class="card">
-          <div class="card-image" style="background: url('/api/placeholder/400/400') center/cover no-repeat;"></div>
+          <div class="card-image" style="background-image: url('RhiannaHeadshot.jpg');"></div>
           <div class="card-content">
             <h3 class="card-title">Rhianna Scyster</h3>
             <p>Founder and Director of Strategy</p>
           </div>
         </div>
         <div class="card">
-          <div class="card-image" style="background: url('/api/placeholder/400/440') center/cover no-repeat;"></div>
+          <div class="card-image" style="background-image: url('RenaldoHorn.jpg');"></div>
           <div class="card-content">
             <h3 class="card-title">Ronaldo Horn</h3>
             <p>Director of Data and Communications</p>
           </div>
         </div>
         <div class="card">
-          <div class="card-image" style="background: url('/api/placeholder/400/420') center/cover no-repeat;"></div>
+          <div class="card-image" style="background-image: url('TLatriceCarmichael.jpg');"></div>
           <div class="card-content">
             <h3 class="card-title">T. Latrice Carmichael</h3>
             <p>Director of Community Engagement</p>
           </div>
         </div>
         <div class="card">
-          <div class="card-image" style="background: url('/api/placeholder/400/400') center/cover no-repeat;"></div>
+          <div class="card-image" style="background-image: url('MoniqueStewart.jpg');"></div>
           <div class="card-content">
             <h3 class="card-title">Monique Stewart</h3>
             <p>Director of Development</p>


### PR DESCRIPTION
## Summary
- ensure card and team images always display as squares
- use real team photos on the home page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68407029d26c832ea30d0d7eacdafc41