### PR TITLE
Add JPEG logo to page headers

### DIFF
--- a/about.html
+++ b/about.html
@@ -268,7 +268,7 @@
     <div class="container">
       <nav>
         <div class="logo">
-          <img src="/api/placeholder/150/60" alt="JPEG Logo">
+          <img src="JPEGLogo.png" alt="JPEG Logo">
         </div>
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>

--- a/index.html
+++ b/index.html
@@ -289,7 +289,7 @@
     <div class="container">
       <nav>
         <div class="logo">
-          <img src="/api/placeholder/150/60" alt="JPEG Logo">
+          <img src="JPEGLogo.png" alt="JPEG Logo">
         </div>
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>

--- a/policy-initiatives.html
+++ b/policy-initiatives.html
@@ -290,7 +290,7 @@
     <div class="container">
       <nav>
         <div class="logo">
-          <img src="/api/placeholder/150/60" alt="JPEG Logo">
+          <img src="JPEGLogo.png" alt="JPEG Logo">
         </div>
         <ul class="nav-links">
           <li><a href="index.html">Home</a></li>


### PR DESCRIPTION
## Summary
- add `JPEGLogo.png` to the header on the home, about, and policy pages
- keep only the `Home`, `About Us`, and `Policy Initiatives` navigation links

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68408e284480832e8dbe1ac88d75ec69