### PR TITLE
Apply Raleway typography

### DIFF
--- a/about.html
+++ b/about.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>About Us - Jacksonville Policy Engagement Group (JPEG)</title>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;700;900&display=swap" rel="stylesheet">
   <style>
     :root {
       --primary-green: #bdcdb6;
@@ -16,7 +17,7 @@
       margin: 0;
       padding: 0;
       box-sizing: border-box;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      font-family: 'Raleway', sans-serif;
     }
     
     body {
@@ -24,6 +25,22 @@
       color: var(--dark-blue);
       line-height: 1.6;
     }
+h1, h2 {
+  font-weight: 900;
+}
+
+h3, h4 {
+  font-weight: 700;
+}
+
+body, p, li {
+  font-weight: 500;
+}
+
+blockquote, .pull-quote {
+  font-style: italic;
+}
+
     
     header {
       background-color: var(--dark-blue);

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Jacksonville Policy Engagement Group (JPEG)</title>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;700;900&display=swap" rel="stylesheet">
   <style>
     :root {
       --primary-green: #bdcdb6;
@@ -16,7 +17,7 @@
       margin: 0;
       padding: 0;
       box-sizing: border-box;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      font-family: 'Raleway', sans-serif;
     }
     
     body {
@@ -24,6 +25,22 @@
       color: var(--dark-blue);
       line-height: 1.6;
     }
+h1, h2 {
+  font-weight: 900;
+}
+
+h3, h4 {
+  font-weight: 700;
+}
+
+body, p, li {
+  font-weight: 500;
+}
+
+blockquote, .pull-quote {
+  font-style: italic;
+}
+
     
     header {
       background-color: var(--dark-blue);

--- a/policy-initiatives.html
+++ b/policy-initiatives.html
@@ -4,6 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Policy Initiatives - Jacksonville Policy Engagement Group (JPEG)</title>
+  <link href="https://fonts.googleapis.com/css2?family=Raleway:wght@400;500;700;900&display=swap" rel="stylesheet">
   <style>
     :root {
       --primary-green: #bdcdb6;
@@ -16,7 +17,7 @@
       margin: 0;
       padding: 0;
       box-sizing: border-box;
-      font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+      font-family: 'Raleway', sans-serif;
     }
     
     body {
@@ -24,6 +25,22 @@
       color: var(--dark-blue);
       line-height: 1.6;
     }
+h1, h2 {
+  font-weight: 900;
+}
+
+h3, h4 {
+  font-weight: 700;
+}
+
+body, p, li {
+  font-weight: 500;
+}
+
+blockquote, .pull-quote {
+  font-style: italic;
+}
+
     
     header {
       background-color: var(--dark-blue);


### PR DESCRIPTION
## Summary
- use Google Fonts link to include the Raleway family
- set global font family to Raleway
- add typography rules so headers are black, subheaders bold, body copy medium and pull quotes italic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6840954b8ea4832e9c934716fbce8898